### PR TITLE
Add environment variable to specify JVM options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM boritzio/docker-base-java
 
-RUN apt-get update && apt-get install -y zookeeper=3.4.*
-
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && apt-get install -y zookeeper=3.4.* \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD zoo.cfg /tmp/zoo.cfg
 ADD jaas.conf /tmp/jaas.conf

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ ZK_SECRETS_PATH #default /secrets
 KERBEROS_KEYTAB_FILE #default zookeeper.keytab
 KERBEROS_PRINCIPAL #should be set to enable SASL and kerberos settings
 
+#optional java options (-Xmx, -Xms, etc)
+JAVA_OPTIONS
+
 DEBUG_CONFIG # set this to print the generated configs
 
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,9 @@ export ZK_INIT_LIMIT=${ZK_INIT_LIMIT:-"10"}
 #KERBEROS_SETTINGS
 export KERBEROS_KEYTAB_FILE=${KEBEROS_KEYTAB_FILE:-"zookeeper.keytab"}
 
+# JVM options
+export JAVA_OPTIONS=${JAVA_OPTIONS:-}
+
 
 mkdir -p $ZK_DATA_DIR
 mkdir -p $ZK_DATA_LOG_DIR
@@ -77,6 +80,7 @@ fi
 
 /usr/bin/java -cp \
   /etc/zookeeper/conf:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar \
+  $JAVA_OPTIONS \
   -Dcom.sun.management.jmxremote \
   -Dcom.sun.management.jmxremote.local.only=false \
   -Dzookeeper.root.logger=INFO,CONSOLE \


### PR DESCRIPTION
- Some JVM options may be useful to set for zookeeper, like the Xmx and
Xms values
- Combine Dockerfile install and cleanup steps to reduce image size slightly